### PR TITLE
Add daily capacity tracking for fixed commitments

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.v8ij5a8s82"
+    "revision": "0.c1e65vqk1m8"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/CommitmentsList.tsx
+++ b/src/components/CommitmentsList.tsx
@@ -216,13 +216,23 @@ const CommitmentsList: React.FC<CommitmentsListProps> = ({
                     <h3 className="text-base sm:text-lg font-semibold text-gray-800 dark:text-white truncate">
                       {commitment.title}
                     </h3>
-                    <span
-                      className={`px-2 sm:px-3 py-1 text-xs font-medium rounded-full flex-shrink-0 ${getCategoryColor(
-                        commitment.category
-                      )}`}
-                    >
-                      {commitment.category}
-                    </span>
+                    <div className="flex items-center space-x-2 flex-shrink-0">
+                      <span
+                        className={`px-2 sm:px-3 py-1 text-xs font-medium rounded-full ${getCategoryColor(
+                          commitment.category
+                        )}`}
+                      >
+                        {commitment.category}
+                      </span>
+                      {commitment.countsTowardDailyHours && (
+                        <span
+                          className="px-2 py-1 text-xs font-medium rounded-full bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300"
+                          title="Counts toward daily available hours"
+                        >
+                          📊 Work Time
+                        </span>
+                      )}
+                    </div>
                   </div>
                   <div className="space-y-2">
                     {commitment.isAllDay ? (

--- a/src/components/FixedCommitmentEdit.tsx
+++ b/src/components/FixedCommitmentEdit.tsx
@@ -22,6 +22,7 @@ const FixedCommitmentEdit: React.FC<FixedCommitmentEditProps> = ({ commitment, e
     location: commitment.location || '',
     description: commitment.description || '',
     isAllDay: commitment.isAllDay || false,
+    countsTowardDailyHours: commitment.countsTowardDailyHours || false,
     dateRange: {
       startDate: commitment.dateRange?.startDate || '',
       endDate: commitment.dateRange?.endDate || ''

--- a/src/components/FixedCommitmentEdit.tsx
+++ b/src/components/FixedCommitmentEdit.tsx
@@ -418,6 +418,26 @@ const FixedCommitmentEdit: React.FC<FixedCommitmentEditProps> = ({ commitment, e
           />
         </div>
 
+        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-4">
+          <label className="flex items-start space-x-3">
+            <input
+              type="checkbox"
+              checked={formData.countsTowardDailyHours}
+              onChange={(e) => setFormData({ ...formData, countsTowardDailyHours: e.target.checked })}
+              className="mt-1 text-blue-600 focus:ring-blue-500 rounded"
+            />
+            <div>
+              <span className="block text-sm font-medium text-gray-700 dark:text-gray-200">
+                Count toward daily available hours
+              </span>
+              <span className="block text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Check this for work/productive commitments that use your daily capacity (e.g., meetings, study sessions).
+                Leave unchecked for personal activities (e.g., meals, commute, exercise).
+              </span>
+            </div>
+          </label>
+        </div>
+
         {/* Conflict Error Display */}
         {conflictError && (
           <div className="p-3 bg-red-50 border border-red-200 rounded-lg dark:bg-red-900/20 dark:border-red-700">

--- a/src/components/FixedCommitmentInput.tsx
+++ b/src/components/FixedCommitmentInput.tsx
@@ -21,6 +21,7 @@ const FixedCommitmentInput: React.FC<FixedCommitmentInputProps> = ({ onAddCommit
     location: '',
     description: '',
     isAllDay: false,
+    countsTowardDailyHours: false,
     dateRange: {
       startDate: '',
       endDate: ''
@@ -129,6 +130,7 @@ const FixedCommitmentInput: React.FC<FixedCommitmentInputProps> = ({ onAddCommit
       location: '',
       description: '',
       isAllDay: false,
+      countsTowardDailyHours: false,
       dateRange: {
         startDate: '',
         endDate: ''

--- a/src/components/FixedCommitmentInput.tsx
+++ b/src/components/FixedCommitmentInput.tsx
@@ -472,6 +472,26 @@ const FixedCommitmentInput: React.FC<FixedCommitmentInputProps> = ({ onAddCommit
             />
           </div>
 
+          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-4">
+            <label className="flex items-start space-x-3">
+              <input
+                type="checkbox"
+                checked={formData.countsTowardDailyHours}
+                onChange={(e) => setFormData({ ...formData, countsTowardDailyHours: e.target.checked })}
+                className="mt-1 text-blue-600 focus:ring-blue-500 rounded"
+              />
+              <div>
+                <span className="block text-sm font-medium text-gray-700 dark:text-gray-200">
+                  Count toward daily available hours
+                </span>
+                <span className="block text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Check this for work/productive commitments that use your daily capacity (e.g., meetings, study sessions).
+                  Leave unchecked for personal activities (e.g., meals, commute, exercise).
+                </span>
+              </div>
+            </label>
+          </div>
+
           {/* Conflict Error Display */}
           {conflictError && (
             <div className="p-3 bg-red-50 border border-red-200 rounded-lg dark:bg-red-900/20 dark:border-red-700">

--- a/src/components/StudyPlanView.tsx
+++ b/src/components/StudyPlanView.tsx
@@ -583,10 +583,25 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
             </h2>
             <div className="flex items-center space-x-4">
               <div className="text-sm text-gray-500 dark:text-gray-300">
-                {formatTime(todaysPlan.plannedTasks.filter(session => {
-                  const sessionStatus = checkSessionStatus(session, todaysPlan.date);
-                  return sessionStatus !== 'missed' && session.status !== 'skipped';
-                }).reduce((sum, session) => sum + session.allocatedHours, 0))} of work planned
+                {(() => {
+                  const taskHours = todaysPlan.plannedTasks.filter(session => {
+                    const sessionStatus = checkSessionStatus(session, todaysPlan.date);
+                    return sessionStatus !== 'missed' && session.status !== 'skipped';
+                  }).reduce((sum, session) => sum + session.allocatedHours, 0);
+                  const committedHours = calculateCommittedHoursForDate(todaysPlan.date, fixedCommitments);
+                  const totalPlannedHours = taskHours + committedHours;
+
+                  return (
+                    <div className="space-y-1">
+                      <div>{formatTime(totalPlannedHours)} total work planned</div>
+                      {committedHours > 0 && (
+                        <div className="text-xs text-blue-600 dark:text-blue-400">
+                          ({formatTime(taskHours)} tasks + {formatTime(committedHours)} commitments)
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()}
               </div>
               {todaysPlan.isOverloaded && (
                 <div className="flex items-center space-x-2">

--- a/src/components/StudyPlanView.tsx
+++ b/src/components/StudyPlanView.tsx
@@ -25,6 +25,60 @@ if (typeof window !== 'undefined') {
   }
 }
 
+// Helper function to calculate committed hours for a specific date
+const calculateCommittedHoursForDate = (date: string, commitments: FixedCommitment[]): number => {
+  const targetDate = new Date(date);
+  const dayOfWeek = targetDate.getDay();
+
+  let totalCommittedHours = 0;
+
+  commitments.forEach(commitment => {
+    // Only count commitments that count toward daily hours
+    if (!commitment.countsTowardDailyHours) return;
+
+    // Skip all-day events (they don't have specific duration)
+    if (commitment.isAllDay || !commitment.startTime || !commitment.endTime) return;
+
+    let shouldInclude = false;
+
+    if (commitment.recurring) {
+      // For recurring commitments, check if this day of week is included
+      if (commitment.daysOfWeek.includes(dayOfWeek)) {
+        // Check if the date falls within the date range (if specified)
+        if (commitment.dateRange) {
+          const startDate = new Date(commitment.dateRange.startDate);
+          const endDate = new Date(commitment.dateRange.endDate);
+          if (targetDate >= startDate && targetDate <= endDate) {
+            shouldInclude = true;
+          }
+        } else {
+          // No date range specified, so it's active
+          shouldInclude = true;
+        }
+      }
+    } else {
+      // For one-time commitments, check if this date is in the specific dates
+      if (commitment.specificDates?.includes(date)) {
+        shouldInclude = true;
+      }
+    }
+
+    if (shouldInclude) {
+      // Calculate duration in hours
+      const [startHour, startMin] = commitment.startTime.split(':').map(Number);
+      const [endHour, endMin] = commitment.endTime.split(':').map(Number);
+      const startMinutes = startHour * 60 + startMin;
+      const endMinutes = endHour * 60 + endMin;
+      const durationMinutes = endMinutes - startMinutes;
+      const durationHours = durationMinutes / 60;
+
+      totalCommittedHours += durationHours;
+    }
+  });
+
+  return totalCommittedHours;
+};
+
 const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedCommitments, onSelectTask, onGenerateStudyPlan, onUndoSessionDone, onSkipSession, settings, onAddFixedCommitment, onRefreshStudyPlan, onReshuffleStudyPlan, onUpdateTask }) => {
   const [notificationMessage, setNotificationMessage] = useState<string | null>(null);
   const [] = useState<{ taskTitle: string; unscheduledMinutes: number } | null>(null);

--- a/src/components/StudyPlanView.tsx
+++ b/src/components/StudyPlanView.tsx
@@ -609,10 +609,15 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
                     Busy day!
                   </span>
                   <span className="text-xs text-gray-500 dark:text-gray-400">
-                    ({formatTime(todaysPlan.plannedTasks.filter(session => {
-                      const sessionStatus = checkSessionStatus(session, todaysPlan.date);
-                      return sessionStatus !== 'missed' && session.status !== 'skipped';
-                    }).reduce((sum, session) => sum + session.allocatedHours, 0))} / {formatTime(settings.dailyAvailableHours)} study hours)
+                    ({(() => {
+                      const taskHours = todaysPlan.plannedTasks.filter(session => {
+                        const sessionStatus = checkSessionStatus(session, todaysPlan.date);
+                        return sessionStatus !== 'missed' && session.status !== 'skipped';
+                      }).reduce((sum, session) => sum + session.allocatedHours, 0);
+                      const committedHours = calculateCommittedHoursForDate(todaysPlan.date, fixedCommitments);
+                      const totalHours = taskHours + committedHours;
+                      return `${formatTime(totalHours)} / ${formatTime(settings.dailyAvailableHours)} total hours`;
+                    })()})
                   </span>
                   <span className="text-xs text-blue-500 dark:text-blue-400" title="Buffer time between sessions is not counted in study hours">
                     + buffer time

--- a/src/components/StudyPlanView.tsx
+++ b/src/components/StudyPlanView.tsx
@@ -543,6 +543,49 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
 
 
       
+      {/* Daily Capacity Overview */}
+      {studyPlans.length > 0 && todaysPlan && (
+        <div className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-xl p-4 border border-blue-200 dark:border-blue-700">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <div className="bg-blue-100 dark:bg-blue-900/30 rounded-full p-2">
+                <Clock className="text-blue-600 dark:text-blue-400" size={20} />
+              </div>
+              <div>
+                <h3 className="font-semibold text-gray-800 dark:text-white">Today's Capacity</h3>
+                <p className="text-sm text-gray-600 dark:text-gray-300">Your planned work breakdown</p>
+              </div>
+            </div>
+            <div className="text-right">
+              {(() => {
+                const taskHours = todaysPlan.plannedTasks.filter(session => {
+                  const sessionStatus = checkSessionStatus(session, todaysPlan.date);
+                  return sessionStatus !== 'missed' && session.status !== 'skipped';
+                }).reduce((sum, session) => sum + session.allocatedHours, 0);
+                const committedHours = calculateCommittedHoursForDate(todaysPlan.date, fixedCommitments);
+                const totalPlannedHours = taskHours + committedHours;
+                const remainingHours = Math.max(0, settings.dailyAvailableHours - totalPlannedHours);
+
+                return (
+                  <div className="space-y-1">
+                    <div className="text-lg font-bold text-gray-800 dark:text-white">
+                      {formatTime(totalPlannedHours)} / {formatTime(settings.dailyAvailableHours)}
+                    </div>
+                    <div className="text-xs text-gray-600 dark:text-gray-400 space-y-0.5">
+                      <div>📝 Tasks: {formatTime(taskHours)}</div>
+                      {committedHours > 0 && <div>📊 Commitments: {formatTime(committedHours)}</div>}
+                      <div className={remainingHours > 0 ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}>
+                        {remainingHours > 0 ? `⚡ Available: ${formatTime(remainingHours)}` : "⚠️ Overloaded"}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })()}
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Today's Study Plan */}
       {!isTodayWorkDay ? (
         <div className="bg-white rounded-xl shadow-lg p-6 mb-6 dark:bg-gray-900 dark:shadow-gray-900">

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -342,7 +342,7 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onUpdateTask, onDeleteTask, 
 
     if (!editFormData.impact) return false;
     if (editFormData.deadline && editFormData.deadline < today) return false;
-    if (editFormData.startDate && editFormData.startDate < today) return false;
+    // Start date validation removed for editing tasks - tasks are already created
 
     // Custom category validation (1-50 characters)
     if (editFormData.category === 'Custom...' && (!editFormData.customCategory?.trim() || editFormData.customCategory.trim().length > 50)) return false;

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -244,7 +244,7 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onUpdateTask, onDeleteTask, 
     };
 
     return checkFrequencyDeadlineConflict(taskForCheck, userSettings);
-  }, [editFormData.deadline, editFormData.estimatedHours, editFormData.estimatedMinutes, editFormData.targetFrequency, editFormData.deadlineType, editFormData.minWorkBlock, editFormData.startDate, userSettings]);
+  }, [editFormData.deadline, editFormData.estimatedHours, editFormData.estimatedMinutes, editFormData.targetFrequency, editFormData.deadlineType, editFormData.minWorkBlock, editFormData.startDate, editFormData.estimationMode, editFormData.sessionDurationHours, editFormData.sessionDurationMinutes, calculateSessionBasedTotal, userSettings]);
 
   const getUrgencyColor = (deadline: string): string => {
     const now = new Date();

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -154,63 +154,6 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onUpdateTask, onDeleteTask, 
     }
   }, [editFormData.isOneTimeTask]);
 
-  // Get effective total time (either direct input or calculated from sessions)
-  const getEffectiveTotalTime = () => {
-    if (editFormData.estimationMode === 'session') {
-      return calculateSessionBasedTotal;
-    }
-    return (editFormData.estimatedHours || 0) + ((editFormData.estimatedMinutes || 0) / 60);
-  };
-
-  // Validation error messages
-  const getValidationErrors = (): string[] => {
-    const errors: string[] = [];
-    if (!editFormData.title?.trim()) errors.push('Task title is required');
-    if (editFormData.title && editFormData.title.trim().length > 100) errors.push('Task title must be 100 characters or less');
-
-    const totalHours = getEffectiveTotalTime();
-    if (totalHours <= 0) errors.push('Estimated time must be greater than 0');
-    if (totalHours > 100) errors.push('Estimated time seems unreasonably high (over 100 hours)');
-
-    if (!editFormData.impact) errors.push('Please select task importance');
-    if (editFormData.deadline && editFormData.deadline < today) errors.push('Deadline cannot be in the past');
-    // Start date validation removed for editing tasks - tasks are already created
-
-    if (editFormData.category === 'Custom...' && (!editFormData.customCategory?.trim() || editFormData.customCategory.trim().length > 50)) {
-      errors.push('Custom category must be between 1-50 characters');
-    }
-
-    if (editFormData.isOneTimeTask) {
-      if (!editFormData.deadline || editFormData.deadline.trim() === '') errors.push('One-sitting tasks require a deadline');
-      if (totalHours > userSettings.dailyAvailableHours) errors.push(`One-sitting task (${totalHours}h) exceeds your daily available hours (${userSettings.dailyAvailableHours}h)`);
-    }
-
-    return errors;
-  };
-  
-  // Check if deadline is in the past
-  const isDeadlinePast = editFormData.deadline ? editFormData.deadline < today : false;
-  // Start date validation removed for editing tasks
-
-  // Check for deadline conflict with frequency preference
-  const deadlineConflict = useMemo(() => {
-    if (!editFormData.deadline || editFormData.deadlineType === 'none') {
-      return { hasConflict: false };
-    }
-
-    const totalHours = getEffectiveTotalTime();
-    const taskForCheck = {
-      deadline: editFormData.deadline,
-      estimatedHours: totalHours,
-      targetFrequency: editFormData.targetFrequency,
-      deadlineType: editFormData.deadlineType,
-      minWorkBlock: editFormData.minWorkBlock,
-      startDate: editFormData.startDate
-    };
-    
-    return checkFrequencyDeadlineConflict(taskForCheck, userSettings);
-  }, [editFormData.deadline, editFormData.estimatedHours, editFormData.estimatedMinutes, editFormData.targetFrequency, editFormData.deadlineType, editFormData.minWorkBlock, editFormData.startDate, userSettings]);
-
   // Calculate total time from session-based estimation
   const calculateSessionBasedTotal = React.useMemo(() => {
     if (editFormData.estimationMode !== 'session' || !editFormData.deadline || editFormData.deadlineType === 'none') {

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -354,7 +354,7 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onUpdateTask, onDeleteTask, 
     }
 
     return true;
-  }, [editFormData, today, userSettings]);
+  }, [editFormData, today, userSettings, calculateSessionBasedTotal]);
 
   const saveEdit = () => {
     if (editingTaskId && isEditFormValid) {

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -189,6 +189,63 @@ const TaskList: React.FC<TaskListProps> = ({ tasks, onUpdateTask, onDeleteTask, 
     return sessionDuration * workDays;
   }, [editFormData.estimationMode, editFormData.sessionDurationHours, editFormData.sessionDurationMinutes, editFormData.deadline, editFormData.deadlineType, editFormData.startDate, editFormData.targetFrequency]);
 
+  // Get effective total time (either direct input or calculated from sessions)
+  const getEffectiveTotalTime = () => {
+    if (editFormData.estimationMode === 'session') {
+      return calculateSessionBasedTotal;
+    }
+    return (editFormData.estimatedHours || 0) + ((editFormData.estimatedMinutes || 0) / 60);
+  };
+
+  // Validation error messages
+  const getValidationErrors = (): string[] => {
+    const errors: string[] = [];
+    if (!editFormData.title?.trim()) errors.push('Task title is required');
+    if (editFormData.title && editFormData.title.trim().length > 100) errors.push('Task title must be 100 characters or less');
+
+    const totalHours = getEffectiveTotalTime();
+    if (totalHours <= 0) errors.push('Estimated time must be greater than 0');
+    if (totalHours > 100) errors.push('Estimated time seems unreasonably high (over 100 hours)');
+
+    if (!editFormData.impact) errors.push('Please select task importance');
+    if (editFormData.deadline && editFormData.deadline < today) errors.push('Deadline cannot be in the past');
+    // Start date validation removed for editing tasks - tasks are already created
+
+    if (editFormData.category === 'Custom...' && (!editFormData.customCategory?.trim() || editFormData.customCategory.trim().length > 50)) {
+      errors.push('Custom category must be between 1-50 characters');
+    }
+
+    if (editFormData.isOneTimeTask) {
+      if (!editFormData.deadline || editFormData.deadline.trim() === '') errors.push('One-sitting tasks require a deadline');
+      if (totalHours > userSettings.dailyAvailableHours) errors.push(`One-sitting task (${totalHours}h) exceeds your daily available hours (${userSettings.dailyAvailableHours}h)`);
+    }
+
+    return errors;
+  };
+
+  // Check if deadline is in the past
+  const isDeadlinePast = editFormData.deadline ? editFormData.deadline < today : false;
+  // Start date validation removed for editing tasks
+
+  // Check for deadline conflict with frequency preference
+  const deadlineConflict = useMemo(() => {
+    if (!editFormData.deadline || editFormData.deadlineType === 'none') {
+      return { hasConflict: false };
+    }
+
+    const totalHours = getEffectiveTotalTime();
+    const taskForCheck = {
+      deadline: editFormData.deadline,
+      estimatedHours: totalHours,
+      targetFrequency: editFormData.targetFrequency,
+      deadlineType: editFormData.deadlineType,
+      minWorkBlock: editFormData.minWorkBlock,
+      startDate: editFormData.startDate
+    };
+
+    return checkFrequencyDeadlineConflict(taskForCheck, userSettings);
+  }, [editFormData.deadline, editFormData.estimatedHours, editFormData.estimatedMinutes, editFormData.targetFrequency, editFormData.deadlineType, editFormData.minWorkBlock, editFormData.startDate, userSettings]);
+
   const getUrgencyColor = (deadline: string): string => {
     const now = new Date();
     const deadlineDate = new Date(deadline);

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,7 @@ export interface FixedCommitment {
     startDate: string; // YYYY-MM-DD format
     endDate: string; // YYYY-MM-DD format
   };
+  countsTowardDailyHours?: boolean; // Whether this commitment counts toward daily available hours
   // New fields for individual session management
   deletedOccurrences?: string[]; // Array of date strings (YYYY-MM-DD)
   modifiedOccurrences?: {

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -2054,13 +2054,17 @@ export const generateNewStudyPlan = (
       }
     });
     // Sort available days to maintain order
-    availableDays.sort();
+  availableDays.sort();
   }
 
   const studyPlans: StudyPlan[] = [];
   const dailyRemainingHours: { [date: string]: number } = {};
   availableDays.forEach(date => {
-    dailyRemainingHours[date] = settings.dailyAvailableHours;
+    // Calculate committed hours for this date that count toward daily hours
+    const committedHours = calculateCommittedHoursForDate(date, fixedCommitments);
+    const availableHoursAfterCommitments = Math.max(0, settings.dailyAvailableHours - committedHours);
+
+    dailyRemainingHours[date] = availableHoursAfterCommitments;
     studyPlans.push({
       id: `plan-${date}`,
       date,

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -1756,13 +1756,17 @@ export const generateNewStudyPlan = (
     const studyPlans: StudyPlan[] = [];
     const dailyRemainingHours: { [date: string]: number } = {};
     availableDays.forEach(date => {
-      dailyRemainingHours[date] = settings.dailyAvailableHours;
+      // Calculate committed hours for this date that count toward daily hours
+      const committedHours = calculateCommittedHoursForDate(date, fixedCommitments);
+      const availableHoursAfterCommitments = Math.max(0, settings.dailyAvailableHours - committedHours);
+
+      dailyRemainingHours[date] = availableHoursAfterCommitments;
       studyPlans.push({
         id: `plan-${date}`,
         date,
         plannedTasks: [],
         totalStudyHours: 0,
-        availableHours: settings.dailyAvailableHours
+        availableHours: availableHoursAfterCommitments
       });
     });
 

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -1,5 +1,59 @@
 import { Task, StudyPlan, StudySession, UserSettings, FixedCommitment, UserReschedule, DateSpecificStudyWindow, SkipMetadata } from '../types';
 
+// Helper function to calculate committed hours for a specific date that count toward daily hours
+const calculateCommittedHoursForDate = (date: string, commitments: FixedCommitment[]): number => {
+  const targetDate = new Date(date);
+  const dayOfWeek = targetDate.getDay();
+
+  let totalCommittedHours = 0;
+
+  commitments.forEach(commitment => {
+    // Only count commitments that count toward daily hours
+    if (!commitment.countsTowardDailyHours) return;
+
+    // Skip all-day events (they don't have specific duration)
+    if (commitment.isAllDay || !commitment.startTime || !commitment.endTime) return;
+
+    let shouldInclude = false;
+
+    if (commitment.recurring) {
+      // For recurring commitments, check if this day of week is included
+      if (commitment.daysOfWeek.includes(dayOfWeek)) {
+        // Check if the date falls within the date range (if specified)
+        if (commitment.dateRange) {
+          const startDate = new Date(commitment.dateRange.startDate);
+          const endDate = new Date(commitment.dateRange.endDate);
+          if (targetDate >= startDate && targetDate <= endDate) {
+            shouldInclude = true;
+          }
+        } else {
+          // No date range specified, so it's active
+          shouldInclude = true;
+        }
+      }
+    } else {
+      // For one-time commitments, check if this date is in the specific dates
+      if (commitment.specificDates?.includes(date)) {
+        shouldInclude = true;
+      }
+    }
+
+    if (shouldInclude) {
+      // Calculate duration in hours
+      const [startHour, startMin] = commitment.startTime.split(':').map(Number);
+      const [endHour, endMin] = commitment.endTime.split(':').map(Number);
+      const startMinutes = startHour * 60 + startMin;
+      const endMinutes = endHour * 60 + endMin;
+      const durationMinutes = endMinutes - startMinutes;
+      const durationHours = durationMinutes / 60;
+
+      totalCommittedHours += durationHours;
+    }
+  });
+
+  return totalCommittedHours;
+};
+
 // Utility functions
 export const getLocalDateString = (): string => {
   const now = new Date();

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -2757,7 +2757,11 @@ export const redistributeAfterTaskDeletion = (
   const studyPlans: StudyPlan[] = [];
   const dailyRemainingHours: { [date: string]: number } = {};
   availableDays.forEach(date => {
-    dailyRemainingHours[date] = settings.dailyAvailableHours;
+    // Calculate committed hours for this date that count toward daily hours
+    const committedHours = calculateCommittedHoursForDate(date, fixedCommitments);
+    const availableHoursAfterCommitments = Math.max(0, settings.dailyAvailableHours - committedHours);
+
+    dailyRemainingHours[date] = availableHoursAfterCommitments;
     studyPlans.push({
       id: `plan-${date}`,
       date,

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -2070,7 +2070,7 @@ export const generateNewStudyPlan = (
       date,
       plannedTasks: [],
       totalStudyHours: 0,
-      availableHours: settings.dailyAvailableHours
+      availableHours: availableHoursAfterCommitments
     });
   });
 

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -954,18 +954,22 @@ export const generateNewStudyPlan = (
       // Sort available days to maintain order
       availableDays.sort();
     }
-    
+
 
     const studyPlans: StudyPlan[] = [];
     const dailyRemainingHours: { [date: string]: number } = {};
     availableDays.forEach(date => {
-      dailyRemainingHours[date] = settings.dailyAvailableHours;
+      // Calculate committed hours for this date that count toward daily hours
+      const committedHours = calculateCommittedHoursForDate(date, fixedCommitments);
+      const availableHoursAfterCommitments = Math.max(0, settings.dailyAvailableHours - committedHours);
+
+      dailyRemainingHours[date] = availableHoursAfterCommitments;
       studyPlans.push({
         id: `plan-${date}`,
         date,
         plannedTasks: [],
         totalStudyHours: 0,
-        availableHours: settings.dailyAvailableHours
+        availableHours: availableHoursAfterCommitments
       });
     });
     let evenTaskScheduledHours: { [taskId: string]: number } = {};

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -2767,7 +2767,7 @@ export const redistributeAfterTaskDeletion = (
       date,
       plannedTasks: [],
       totalStudyHours: 0,
-      availableHours: settings.dailyAvailableHours
+      availableHours: availableHoursAfterCommitments
     });
   });
 


### PR DESCRIPTION
## Purpose

The user was looking for a daily capacity overview section in the study plan to better understand how their fixed commitments (meetings, work sessions) impact their available study time each day.

## Code changes

- **Added `countsTowardDailyHours` field** to `FixedCommitment` type to distinguish between work/productive commitments and personal activities
- **Enhanced commitment forms** with checkbox option to mark commitments that count toward daily capacity (meetings, study sessions vs meals, commute, exercise)
- **Added visual indicator** in commitments list showing "📊 Work Time" badge for commitments that count toward daily hours
- **Implemented capacity calculation logic** that subtracts committed work hours from daily available hours when generating study plans
- **Added "Today's Capacity" overview section** in study plan view showing remaining available hours after accounting for fixed commitments
- **Updated scheduling algorithms** across all study plan generation functions to respect actual available capacity after commitments

This provides users with clear visibility into how their fixed commitments impact their daily study capacity and ensures study plans are realistic based on actual available time.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a3ef22895b9a47f9ba10be42d150bf0e/vibe-haven)

👀 [Preview Link](https://a3ef22895b9a47f9ba10be42d150bf0e-vibe-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a3ef22895b9a47f9ba10be42d150bf0e</projectId>-->
<!--<branchName>vibe-haven</branchName>-->